### PR TITLE
FIX: WIndows build break bc of missing API export tag

### DIFF
--- a/include/flecs_systems_prometheus.h
+++ b/include/flecs_systems_prometheus.h
@@ -16,6 +16,7 @@ typedef struct FlecsSystemsPrometheus {
     ECS_DECLARE_COMPONENT(EcsPrometheus);
 } FlecsSystemsPrometheus;
 
+FLECS_SYSTEMS_PROMETHEUS_EXPORT
 void FlecsSystemsPrometheusImport(
     ecs_world_t *world,
     int flags);


### PR DESCRIPTION
MSVC won't generate a dll import lib if there are no symbols marked as exported.
Solution: Add FLECS_SYSTEMS_PROMETHEUS_EXPORT to FlecsSystemsPrometheusImport